### PR TITLE
Fix drive connection events for some SD readers

### DIFF
--- a/hactoolgui/Services/SDService.cs
+++ b/hactoolgui/Services/SDService.cs
@@ -33,7 +33,6 @@ namespace HACGUI.Services
                 string driveName = ((ManagementBaseObject)e.NewEvent["TargetInstance"]).Properties["DeviceID"].Value.ToString();
                 DriveInfo actedDrive = new DriveInfo(driveName);
                 DirectoryInfo actedDriveInfo = actedDrive.RootDirectory;
-                Console.WriteLine(e.NewEvent.ClassPath.ClassName);
 
                 if (actedDrive.IsReady) {
                     if (Validator(actedDriveInfo)) {


### PR DESCRIPTION
My SD card reader doesn't trigger the original drive change events for whatever reason. This uses an alternative method that _just works™._